### PR TITLE
Support localstack S3 endpoints with Spark + Hadoop 2.7.3

### DIFF
--- a/hadoop-project/pom.xml
+++ b/hadoop-project/pom.xml
@@ -61,7 +61,7 @@
     <java.security.egd>file:///dev/urandom</java.security.egd>
 
     <!-- avro version -->
-    <avro.version>1.7.4</avro.version>
+    <avro.version>1.9.0</avro.version>
 
     <!-- jersey version -->
     <jersey.version>1.9</jersey.version>

--- a/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
+++ b/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/Constants.java
@@ -35,6 +35,10 @@ public class Constants {
 
   //use a custom endpoint?
   public static final String ENDPOINT = "fs.s3a.endpoint";
+
+  //Enable path style access? Overrides default virtual hosting
+  public static final String PATH_STYLE_ACCESS = "fs.s3a.path.style.access";
+
   //connect to s3 through a proxy server?
   public static final String PROXY_HOST = "fs.s3a.proxy.host";
   public static final String PROXY_PORT = "fs.s3a.proxy.port";


### PR DESCRIPTION
- Add the PATH_STYLE_ACCESS conf setting (introduced in later Hadoop versions) allowing Hadoop to make valid requests to the localstack S3 endpoint (e.g. http://localstack:4572/my-bucket/file instead of http://my-bucket.localstack:4572/file)

- Remove the setting of metadata in the file writes, since localstack is not computing the MD5 the client expects and an error is raised after successful transfer if checked

- Bump avro-tools up to 1.9.0 to avoid NoSuchMethod error when reading AVRO files